### PR TITLE
Allow extra args

### DIFF
--- a/beanstalkd/templates/statefulset.yaml
+++ b/beanstalkd/templates/statefulset.yaml
@@ -55,6 +55,9 @@ spec:
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         args:
         - -z {{ .Values.beanstalkd.maxJobSize }}
+{{- with .Values.beanstalkd.extraArgs }}
+{{ . | toYaml | nindent 8 }}
+{{- end }}
         ports:
         - name: beanstalkd
           containerPort: 11300

--- a/beanstalkd/values.yaml
+++ b/beanstalkd/values.yaml
@@ -10,6 +10,7 @@ AntiAffinity: "hard"
 beanstalkd:
   maxJobSize: 65535
   binlogSize: "20Mi"
+  extraArgs: []
 
 service:
   port: 11300


### PR DESCRIPTION
I think fixes #2 by allowing you to set
```yaml
beanstalkd:
  extraArgs:
    - -u
    - root
```